### PR TITLE
feat: 라이브러리 추가 및 유니버스 entity 객체 생

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'com.example.replay'
+group = 'com.example.replay' 
 version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
 
@@ -25,13 +25,25 @@ repositories {
 }
 
 dependencies {
+	//JPA & DB 
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa' 
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
-	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
+
+	//MyBatis
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
+
+	//Web & Security
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation' 
+	
+	//Util & Dev
+	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools' 
+
+	//Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/kh/replay/global/common/ResponseData.java
+++ b/src/main/java/com/kh/replay/global/common/ResponseData.java
@@ -5,22 +5,22 @@ import lombok.Data;
 
 @Builder
 @Data
-public class ApiResponse<T> {
+public class ResponseData<T> {
 	
 	private boolean success;
 	private String message;
 	private T data;
 	
-	public static <T> ApiResponse<T> success(String message, T data) {
-		return ApiResponse.<T>builder()
+	public static <T> ResponseData<T> success(String message, T data) {
+		return ResponseData.<T>builder()
 						  .success(true)
 						  .message(message)
 						  .data(data)
 						  .build();
 	}
 	
-	public static <T> ApiResponse<T> failure(String message) {
-		return ApiResponse.<T>builder()
+	public static <T> ResponseData<T> failure(String message) {
+		return ResponseData.<T>builder()
 						  .success(false)
 						  .message(message)
 						  .data(null)

--- a/src/main/java/com/kh/replay/global/exception/GlobalHandlerException.java
+++ b/src/main/java/com/kh/replay/global/exception/GlobalHandlerException.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import com.kh.replay.global.common.ApiResponse;
+import com.kh.replay.global.common.ResponseData;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,14 +14,14 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalHandlerException {
 
 	/* 공통 응답 포맷 */
-	private ResponseEntity<ApiResponse<?>> createErrorResponseEntity(Exception e, HttpStatus status) {
-		ApiResponse<?> error = ApiResponse.failure(e.getMessage());
+	private ResponseEntity<ResponseData<?>> createErrorResponseEntity(Exception e, HttpStatus status) {
+		ResponseData<?> error = ResponseData.failure(e.getMessage());
 		return ResponseEntity.status(status).body(error);
 	}
 	
 	// 잘못된 상태 전달시
 	@ExceptionHandler(IllegalStateException.class)
-	public ResponseEntity<ApiResponse<?>> handleIllegalArgumentException(IllegalStateException e) {
+	public ResponseEntity<ResponseData<?>> handleIllegalArgumentException(IllegalStateException e) {
 		log.error("잘못된 상태 : {}", e.getMessage());
 		return createErrorResponseEntity(e, HttpStatus.BAD_REQUEST);
 	}

--- a/src/main/java/com/kh/replay/global/universe/model/entity/Universe.java
+++ b/src/main/java/com/kh/replay/global/universe/model/entity/Universe.java
@@ -1,0 +1,53 @@
+package com.kh.replay.global.universe.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "TB_UNIVERSE")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@DynamicInsert 
+public class Universe {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_UNIVERSE_GEN")
+    @SequenceGenerator(name = "SEQ_UNIVERSE_GEN", sequenceName = "SEQ_UNIVERSE_ID", allocationSize = 1)
+    @Column(name = "UNIVERSE_ID")
+    private Long universeId;
+
+    @Column(name = "TITLE", nullable = false, length = 100)
+    private String title;
+
+    @Lob // CLOB 데이터 처리
+    @Column(name = "LAYOUT_DATA")
+    private String layoutData;
+
+    @Column(name = "THEME_CODE", length = 50)
+    private String themeCode;
+
+    @Column(name = "STATUS", length = 1)
+    @ColumnDefault("'Y'")
+    private String status;
+
+    @Column(name = "MEMBER_ID", nullable = false)
+    private String memberId;
+
+    @Column(name = "CREATED_AT", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "UPDATED_AT", nullable = false)
+    private LocalDateTime updatedAt;
+    
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+}


### PR DESCRIPTION
feat: 라이브러리 추가 및 유니버스 entity 객체 생

- DB 유니버스 테이블 양식에 맞춰서 entity 생성
- @entity @table 사용을 위한 라이브러리 추가
implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

- 서버 켜져있어도 새로고침 없이 자동으로 저장사항 반영되는 라이브러리 추가 
developmentOnly 'org.springframework.boot:spring-boot-devtools' 

라이브러리가 최신버전인지도 추가 검토 부탁드립니다 / 응답데이터 객체 추가못했습니다 다음작업할때 주영님이 반영부탁드립니다 