### PR TITLE
Feat: 공지사항 등록/수정/삭제 권한 체크 메소드 생성 및 공지사항 전체 주석작성

### DIFF
--- a/src/main/java/com/kh/replay/notice/controller/NoticeController.java
+++ b/src/main/java/com/kh/replay/notice/controller/NoticeController.java
@@ -31,12 +31,18 @@ public class NoticeController {
 	private final NoticeService noticeService;
 	
 	/**
-	 * 공지사항 전체 조회
-	 * @param page
-	 * @param size
-	 * @param keyword
-	 * @param status
-	 * @return
+	 * 공지사항 목록 조회
+	 * - 상태(status) 기준 필터링
+	 * - 제목 키워드 검색 지원
+	 * - 페이징 처리
+	 *
+	 * 관리자 공지사항 관리 화면에서 사용하는 목록 조회 API
+	 *
+	 * @param page    현재 페이지 번호 (기본값: 1)
+	 * @param size    페이지당 조회 개수 (기본값: 10)
+	 * @param keyword 검색 키워드 (nullable)
+	 * @param status  공지사항 상태 (기본값: Y)
+	 * @return 공지사항 목록 및 페이징 정보
 	 */
 	@GetMapping
 	public ResponseEntity<ResponseData<NoticeListResponseDto>> getNoticeList(
@@ -56,9 +62,13 @@ public class NoticeController {
 	
 	/**
 	 * 공지사항 등록
-	 * @param requestDto
-	 * @param image
-	 * @return
+	 * - 관리자 전용 기능
+	 * - 공지사항 제목/내용을 Form-Data 방식으로 전달
+	 * - 이미지가 있을 경우 MultipartFile로 함께 업로드
+	 *
+	 * @param requestDto 공지사항 등록 요청 DTO (제목, 내용)
+	 * @param image      첨부 이미지 파일 (nullable)
+	 * @return 등록 결과 응답 (201 Created)
 	 */
 	@PostMapping("/register")
 	public ResponseEntity<ResponseData<Void>> registerNotice(
@@ -73,9 +83,14 @@ public class NoticeController {
 	}
 	
 	/**
-	 * 공지사항 상세조회
-	 * @param noticeNo
-	 * @return
+	 * 공지사항 상세 조회
+	 * - 공지사항 번호 기준 단건 조회
+	 * - 공지사항 본문과 연결된 이미지 목록을 함께 반환
+	 *
+	 * 관리자 공지사항 관리 화면에서 상세 확인 용도
+	 *
+	 * @param noticeNo 공지사항 번호
+	 * @return 공지사항 상세 정보
 	 */
 	@GetMapping("/{noticeNo}")
 	public ResponseEntity<ResponseData<NoticeDetailResponseDto>> getNoticeDetail(@PathVariable("noticeNo") Long noticeNo){
@@ -86,9 +101,15 @@ public class NoticeController {
 	
 	/**
 	 * 공지사항 수정
-	 * @param noticeNo
-	 * @param requestDto
-	 * @return
+	 * - 관리자 전용 기능
+	 * - 공지사항 제목/내용 수정
+	 * - 선택된 이미지 삭제 및 신규 이미지 추가 처리
+	 *
+	 * Multipart/Form-Data 방식으로 요청을 처리한다.
+	 *
+	 * @param noticeNo  공지사항 번호
+	 * @param requestDto 공지사항 수정 요청 DTO
+	 * @return 수정 결과 응답
 	 */
 	@PutMapping(value="/{noticeNo}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ResponseEntity<ResponseData<Void>> updateNotice(
@@ -103,9 +124,13 @@ public class NoticeController {
 	}
 
 	/**
-	 * 공지사항 삭제(소프트)
-	 * @param noticeNo
-	 * @return
+	 * 공지사항 삭제 (소프트 삭제)
+	 * - 관리자 전용 기능
+	 * - 공지사항 상태를 비활성화 처리
+	 * - 연결된 이미지도 함께 소프트 삭제
+	 *
+	 * @param noticeNo 공지사항 번호
+	 * @return 삭제 결과 응답
 	 */
 	@DeleteMapping("/{noticeNo}")
 	public ResponseEntity<ResponseData<Void>> deleteNotice(@PathVariable("noticeNo") Long noticeNo){

--- a/src/main/java/com/kh/replay/notice/model/repository/NoticeRepository.java
+++ b/src/main/java/com/kh/replay/notice/model/repository/NoticeRepository.java
@@ -9,39 +9,125 @@ import com.kh.replay.notice.model.domain.Notice;
 import com.kh.replay.notice.model.domain.NoticeImg;
 import com.kh.replay.notice.model.dto.NoticeUpdateRequestDto;
 
+/**
+ * 공지사항 관련 DB 접근을 담당하는 MyBatis Mapper 인터페이스
+ * - 공지사항 CRUD
+ * - 공지사항 이미지 관리
+ * - 목록 조회 및 페이징 처리
+ */
 @Mapper
 public interface NoticeRepository {
 
-	// 공지사항 전체 목록 조회
+	/**
+     * 공지사항 목록 조회
+     * - 상태(status) 기준 필터링
+     * - 제목 키워드 검색 지원
+     * - OFFSET / LIMIT 기반 페이징 처리
+     *
+     * @param keyword 검색 키워드 (nullable)
+     * @param status  공지사항 상태 (Y/N)
+     * @param offset  조회 시작 위치
+     * @param limit   조회 개수
+     * @return 공지사항 엔티티 목록
+     */
 	List<Notice> findAll(@Param("keyword") String keyword,@Param("status") String status,@Param("offset") int offset, @Param("limit")int limit);
 	
+	/**
+     * 공지사항 전체 개수 조회
+     * - 목록 페이징 처리를 위한 total count
+     * - 목록 조회 조건과 동일한 필터 적용
+     *
+     * @param keyword 검색 키워드 (nullable)
+     * @param status  공지사항 상태 (Y/N)
+     * @return 공지사항 총 개수
+     */
 	int countAll(@Param("keyword") String keyword, @Param("status") String status);
 
-	// 공지사항 상세 조회
+	/**
+     * 공지사항 단건 조회
+     * - 공지사항 번호 기준 조회
+     *
+     * @param noticeNo 공지사항 번호
+     * @return 공지사항 엔티티 (없을 경우 null)
+     */
 	Notice findByNoticeNo(Long noticeNo);
 	
+	/**
+     * 특정 공지사항에 등록된 이미지 URL 목록 조회
+     * - 활성 상태(STATUS = 'Y')인 이미지만 조회
+     *
+     * @param noticeNo 공지사항 번호
+     * @return 이미지 URL 목록
+     */
 	List<String> findImageUrlsByNoticeNo(Long noticeNo);
 	
-	// 공지사항 작성
+	/**
+     * 공지사항 등록
+     *
+     * @param notice 공지사항 엔티티
+     * @return 처리된 행 수
+     */
 	int save(Notice notice);
 	
+	/**
+     * 공지사항 이미지 등록
+     *
+     * @param noticeImg 공지사항 이미지 엔티티
+     * @return 처리된 행 수
+     */
 	int saveImg(NoticeImg noticeImg);
 
-	// 공지사항 수정
+	/**
+     * 공지사항 본문 수정
+     * - 제목, 내용 수정
+     * - UPDATED_AT 갱신
+     *
+     * @param noticeNo 공지사항 번호
+     * @param req      수정 요청 DTO
+     * @return 처리된 행 수
+     */
 	int updateNotice(@Param("noticeNo") Long noticeNo,
 					 @Param("req") NoticeUpdateRequestDto req);
 	
-	// 이미지 삭제(소프트)
+	/**
+     * 공지사항 이미지 소프트 삭제
+     * - IMG_ID 목록 기준
+     * - STATUS 값을 'Y' → 'N'으로 변경
+     *
+     * @param imgIds 삭제할 이미지 ID 목록
+     * @return 처리된 행 수
+     */
 	int deleteNoticeImages(List<Long> imgIds);
 	
+	/**
+     * 공지사항 이미지 추가
+     * - 공지사항 수정 시 신규 이미지 등록 용도
+     *
+     * @param noticeNo   공지사항 번호
+     * @param originName 원본 파일명
+     * @param changeName 저장된 파일명(S3 URL)
+     * @return 처리된 행 수
+     */
 	int insertNoticeImage(@Param("noticeNo") Long noticeNo,
 						  @Param("originName") String originName,
 						  @Param("changeName") String changeName);
 	
-	// 공지사항 삭제(소프트 삭제)
+	/**
+     * 공지사항 소프트 삭제
+     * - STATUS 값을 'Y' → 'N'으로 변경
+     *
+     * @param noticeNo 공지사항 번호
+     * @return 처리된 행 수
+     */
 	int deleteNotice(Long noticeNo);
 	
-	// 해당 공지 이미지 ID 목록
+	 /**
+     * 특정 공지사항에 연결된 이미지 ID 목록 조회
+     * - 이미지 삭제 처리를 위한 사전 조회
+     *
+     * @param noticeNo 공지사항 번호
+     * @return 이미지 ID 목록
+     */
 	List<Long> findImgIdsByNoticeNo(Long noticeNo);
 	
 }

--- a/src/main/java/com/kh/replay/notice/service/NoticeService.java
+++ b/src/main/java/com/kh/replay/notice/service/NoticeService.java
@@ -7,18 +7,66 @@ import com.kh.replay.notice.model.dto.NoticeListResponseDto;
 import com.kh.replay.notice.model.dto.NoticeRequestDto;
 import com.kh.replay.notice.model.dto.NoticeUpdateRequestDto;
 
+/**
+ * 공지사항 비즈니스 로직을 정의하는 Service 인터페이스
+ * - 공지사항 CRUD
+ * - 관리자 권한 검증
+ * - 이미지 업로드 및 관리
+ */
 public interface NoticeService {
 
-	// 공지사항 목록 조회
+	/**
+     * 공지사항 목록 조회
+     * - 상태(status) 기준 필터링
+     * - 제목 키워드 검색 지원
+     * - 페이징 처리
+     *
+     * @param page    현재 페이지 번호 (1부터 시작)
+     * @param size    페이지당 조회 개수
+     * @param keyword 검색 키워드 (nullable)
+     * @param status  공지사항 상태 (Y/N)
+     * @return 공지사항 목록 및 페이징 정보 DTO
+     */
 	NoticeListResponseDto getNoticeList(int page, int size, String keyword, String status);
 
-	// 공지사항 등록
+	/**
+     * 공지사항 등록
+     * - 관리자 권한 필요
+     * - 공지사항 본문 저장
+     * - 이미지가 있을 경우 S3 업로드 후 별도 테이블에 저장
+     *
+     * @param requestDto 공지사항 등록 요청 DTO
+     * @param image      첨부 이미지 파일 (nullable)
+     */
 	void registerNotice(NoticeRequestDto requestDto, MultipartFile image);
 
-	// 공지사항 상세 조회
+	/**
+     * 공지사항 상세 조회
+     * - 활성 상태(Y) 공지사항만 조회 가능
+     * - 공지사항 본문 + 이미지 목록 반환
+     *
+     * @param noticeNo 공지사항 번호
+     * @return 공지사항 상세 정보 DTO
+     */
 	NoticeDetailResponseDto getNoticeDetail(Long noticeNo);
-
+	
+	/**
+     * 공지사항 수정
+     * - 관리자 권한 필요
+     * - 공지사항 본문 수정
+     * - 이미지 삭제 및 신규 이미지 추가 처리
+     *
+     * @param noticeNo   공지사항 번호
+     * @param requestDto 공지사항 수정 요청 DTO
+     */
 	void updateNotice(Long noticeNo, NoticeUpdateRequestDto requestDto);
-
+	
+	/**
+     * 공지사항 삭제 (소프트 삭제)
+     * - 관리자 권한 필요
+     * - 공지사항 및 연결된 이미지 상태값 변경
+     *
+     * @param noticeNo 공지사항 번호
+     */
 	void deleteNotice(Long noticeNo);
 }

--- a/src/main/resources/mapper/notice-mapper.xml
+++ b/src/main/resources/mapper/notice-mapper.xml
@@ -15,6 +15,10 @@
 		<result property="updatedAt" column="UPDATED_AT" />
 	</resultMap>
 
+	<!-- 공지사항 목록 조회 -->
+	<!-- 상태값(status) 기준 필터링 및 제목 키워드 검색 지원 -->
+	<!-- 최신 공지사항이 먼저 노출되도록 내림차순 정렬 -->
+	<!-- OFFSET / FETCH NEXT 를 이용한 페이징 처리 -->
 	<select id="findAll" resultMap="noticeResultSet">
 		SELECT
 		       *
@@ -41,6 +45,8 @@
 		OFFSET #{offset} ROWS FETCH NEXT #{limit} ROWS ONLY		
 	</select>
 
+	<!-- 공지사항 목록 페이징을 위한 전체 데이터 개수 조회 -->
+	<!-- 상태값 및 키워드 조건을 목록 조회와 동일하게 적용 -->
 	<select id="countAll" resultType="_int">
 		SELECT
 		       COUNT(*)
@@ -54,6 +60,9 @@
 		</if>
 	</select>
 
+	<!-- 공지사항 신규 등록 -->
+	<!-- 시퀀스를 이용해 공지사항 번호를 미리 생성 -->
+	<!-- 기본 상태값은 'Y', 생성/수정 시간은 SYSDATE로 처리 -->
 	<insert id="save" parameterType="com.kh.replay.notice.model.domain.Notice">
 		<selectKey keyProperty="noticeNo" resultType="long" order="BEFORE">
 			SELECT SEQ_NOTICE_NO.NEXTVAL FROM DUAL
@@ -80,7 +89,9 @@
 	    	 , SYSDATE  
 	    	   )
 	</insert>
-
+	
+	<!-- 공지사항에 첨부된 이미지 정보 저장 -->
+	<!-- 이미지 파일명(origin/change)과 공지사항 번호를 매핑 -->
 	<insert id="saveImg" parameterType="com.kh.replay.notice.model.domain.NoticeImg">
 		INSERT 
 		  INTO 
@@ -102,6 +113,8 @@
 				)
 	</insert>
 	
+	<!-- 공지사항 상세 조회 -->
+	<!-- 공지사항 번호 기준 단건 조회 -->
 	<select id="findById" resultMap="noticeResultSet">
 		SELECT
 		       NOTICE_NO
@@ -117,6 +130,8 @@
 	           NOTICE_NO = #{id}
 	</select>
 	
+	<!-- 공지사항 수정 화면에서 사용할 단건 조회 -->
+	<!-- 컬럼을 도메인 필드명으로 alias 처리 -->
 	<select id="findByNoticeNo"
 			resultType="com.kh.replay.notice.model.domain.Notice">
 		SELECT
@@ -131,6 +146,9 @@
 		       NOTICE_NO = #{noticeNo}
 	</select>
 	
+	<!-- 특정 공지사항에 등록된 이미지 목록 조회 -->
+	<!-- 사용중인 이미지(STATUS = 'Y')만 조회 -->
+	<!-- 이미지 순서를 보장하기 위해 IMG_ID 기준 정렬 -->
 	<select id="findImageUrlsByNoticeNo"
 			resultType="string">
 		SELECT
@@ -146,6 +164,8 @@
 		       IMG_ID ASC 		
 	</select>
 	
+	<!-- 공지사항 제목 및 내용 수정 -->
+	<!-- 수정 시 UPDATED_AT 갱신 -->
 	<update id="updateNotice">
 		UPDATE
 		       TB_NOTICE
@@ -157,6 +177,8 @@
 		       NOTICE_NO = #{noticeNo}
 	</update>
 	
+	<!-- 선택된 공지사항 이미지 논리 삭제 -->
+	<!-- IMG_ID 목록을 받아 STATUS 값을 'N'으로 변경 -->
 	<update id="deleteNoticeImages">
 		UPDATE
 		       TB_NOTICE_IMG
@@ -169,6 +191,8 @@
 		</foreach>
 	</update>
 	
+	<!-- 공지사항 수정 시 신규 이미지 추가 -->
+	<!-- 기존 이미지 삭제 후 새로운 이미지 삽입 용도 -->
 	<insert id="insertNoticeImage">
 		INSERT
 		  INTO
@@ -190,6 +214,8 @@
 	   		   )
 	</insert>
 	
+	<!-- 공지사항에 연결된 이미지 ID 목록 조회 -->
+	<!-- 이미지 삭제 처리를 위한 사전 조회 -->
 	<select id="findImgIdsByNoticeNo">
 		SELECT
 		       IMG_ID
@@ -201,6 +227,8 @@
 		       STATUS = 'Y'     
 	</select>
 	
+	<!-- 공지사항 논리 삭제 -->
+	<!-- 실제 데이터 삭제가 아닌 STATUS 값 변경 -->
 	<update id="deleteNotice">
 		UPDATE
 		       TB_NOTICE


### PR DESCRIPTION
📌 작업 내용
- 공지사항 등록/수정/삭제 시 관리자 권한을 검증하는 assertAdmin() 메서드 추가
- Service 레벨에서 인증, 인가를 한번더 검증하여 보안 강화
- 공지사항 Service / Repository / Controller 주석 정리

🔗 관련 이슈

-

📸 스크린샷 (선택)

<img width="708" height="332" alt="image" src="https://github.com/user-attachments/assets/5d290cf5-55df-45bc-bafb-2895768ed59f" />

✅ 체크리스트
[✅] Postman을 통해 API 정상 동작 확인
[✅] 불필요한 로그 및 주석 제거
[✅] 컨벤션을 준수

🙏 리뷰어에게
- Service 레벨에서 권한 및 상태 검증을 공통 메서드로 분리하여 중복 로직을 줄이고 유지보부성 개선
